### PR TITLE
update api.md - corrected example to use named import

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -36,7 +36,7 @@ In the following examples, the options passed to PurgeCSS are the same as the on
 
 ### ES Module Import Syntax
 ```javascript
-import PurgeCSS from 'purgecss'
+import { PurgeCSS } from 'purgecss'
 const purgeCSSResult = await new PurgeCSS().purge({
   content: ['**/*.html'],
   css: ['**/*.css']


### PR DESCRIPTION
## Proposed changes

Docs update: api.md - Instructions for importing purgecss are currently incorrect in esm example (i assumed this is left over from past api?), It should be a named export. I was tripped up by this myself so thought I should make a PR while I'm here.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

n/a

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

N/a